### PR TITLE
Add INSTRUCTION placeholder to prompt template

### DIFF
--- a/prompt_template.txt
+++ b/prompt_template.txt
@@ -18,4 +18,4 @@ outdir = './tmp'
 prefix = 'test'
 restart_mode = 'from_scratch'
 
-Write a scf calculation using mixing_beta = 0.6 for the given geometry.
+<<INSTRUCTION>>


### PR DESCRIPTION
## Summary
- insert `<<INSTRUCTION>>` placeholder into `prompt_template.txt`
- confirm `generate_prompt_from_triples()` replaces both placeholders

## Testing
- `python -m py_compile utils.py`
- `python - <<'PY'
from utils import generate_prompt_from_triples
triples=[{"subject":"Si","predicate":"has lattice constant","object":"5.43"},{"subject":"scf","predicate":"uses mixing","object":"0.4"}]
print(generate_prompt_from_triples(triples,"Write a scf calc"))
PY`

------
https://chatgpt.com/codex/tasks/task_e_686bbc72bad0832e96b43a932870c82a