### PR TITLE
Add docstrings and type hints

### DIFF
--- a/policy_model.py
+++ b/policy_model.py
@@ -2,7 +2,20 @@ import torch
 import torch.nn as nn
 
 class TripleScoringModel(nn.Module):
-    def __init__(self, vocab_size, predicate_size, embedding_dim=32):
+    """Neural network for scoring knowledge graph triples."""
+
+    def __init__(self, vocab_size: int, predicate_size: int, embedding_dim: int = 32) -> None:
+        """Construct the model.
+
+        Parameters
+        ----------
+        vocab_size:
+            Size of the entity vocabulary.
+        predicate_size:
+            Number of unique predicates.
+        embedding_dim:
+            Dimensionality of the entity and predicate embeddings.
+        """
         super().__init__()
         self.entity_embedding = nn.Embedding(vocab_size, embedding_dim)
         self.predicate_embedding = nn.Embedding(predicate_size, embedding_dim)
@@ -10,7 +23,22 @@ class TripleScoringModel(nn.Module):
         # ⬇️ Scoring layer: [s | p | o] → score
         self.fc = nn.Linear(embedding_dim * 3, 1)
 
-    def forward(self, triple_ids):
+    def forward(self, triple_ids: torch.Tensor) -> torch.Tensor:
+        """Score a batch of triples.
+
+        Parameters
+        ----------
+        triple_ids:
+            Tensor of shape ``(batch_size, 3)`` containing subject,
+            predicate and object token IDs. A 1-D tensor of length 3 is
+            also accepted and will be treated as a batch of size one.
+
+        Returns
+        -------
+        torch.Tensor
+            Tensor of scores with shape ``(batch_size,)``.
+        """
+
         # Ensure the input is 2D: [batch_size, 3]
         if triple_ids.ndim == 1:
             triple_ids = triple_ids.unsqueeze(0)

--- a/sample_triples.py
+++ b/sample_triples.py
@@ -1,6 +1,39 @@
 import torch
 
-def select_topk_triples(model, triples, k, entity2id, predicate2id, return_ids=False):
+def select_topk_triples(
+    model: torch.nn.Module,
+    triples: list,
+    k: int,
+    entity2id: dict,
+    predicate2id: dict,
+    return_ids: bool = False,
+) -> list | tuple[list, list]:
+    """Select the top ``k`` scoring triples using ``model``.
+
+    Parameters
+    ----------
+    model:
+        ``TripleScoringModel`` or compatible module that returns a score for
+        each triple.
+    triples:
+        Iterable of dictionaries with ``subject``, ``predicate`` and ``object``
+        keys.
+    k:
+        Number of triples to return.
+    entity2id:
+        Mapping from entity strings to integer IDs.
+    predicate2id:
+        Mapping from predicate strings to integer IDs.
+    return_ids:
+        If ``True``, also return the encoded ID representation of each triple.
+
+    Returns
+    -------
+    list | tuple[list, list]
+        Either the top ``k`` triples or a tuple of triples and their encoded
+        IDs if ``return_ids`` is ``True``.
+    """
+
     encoded = []
     valid_triples = []
     for t in triples:

--- a/utils.py
+++ b/utils.py
@@ -1,8 +1,27 @@
 import os
+from typing import Iterable, Dict, Any
 
-def generate_prompt_from_triples(triples, instruction, template_path="prompt_template.txt"):
-    """
-    Given a list of triples and a user instruction, fill in the prompt template.
+def generate_prompt_from_triples(
+    triples: Iterable[Dict[str, Any]],
+    instruction: str,
+    template_path: str = "prompt_template.txt",
+) -> str:
+    """Fill in a prompt template using provided triples.
+
+    Parameters
+    ----------
+    triples:
+        Iterable of dictionaries with ``subject``, ``predicate`` and ``object``
+        keys.
+    instruction:
+        Text instruction appended to the template.
+    template_path:
+        Location of the prompt template file.
+
+    Returns
+    -------
+    str
+        Completed prompt with triples and instruction inserted.
     """
     with open(template_path) as f:
         template = f.read()
@@ -14,9 +33,20 @@ def generate_prompt_from_triples(triples, instruction, template_path="prompt_tem
     return template.replace("<<FACTS>>", facts.strip()).replace("<<INSTRUCTION>>", instruction)
 
 
-def compute_reward(generated_input, ground_truth_input):
-    """
-    Reward function based on line-level overlap.
+def compute_reward(generated_input: str, ground_truth_input: str) -> float:
+    """Compute a reward for generated content.
+
+    Parameters
+    ----------
+    generated_input:
+        Text produced by the language model.
+    ground_truth_input:
+        Reference `.in` file text used as ground truth.
+
+    Returns
+    -------
+    float
+        Jaccard similarity between generated and reference files.
     """
     gen_lines = set(generated_input.strip().splitlines())
     gt_lines = set(ground_truth_input.strip().splitlines())
@@ -25,12 +55,32 @@ def compute_reward(generated_input, ground_truth_input):
     return len(overlap) / len(union) if union else 0.0
 
 
-def generate_qe_input_from_prompt(prompt, openai_client, temperature=0.7):
+def generate_qe_input_from_prompt(
+    prompt: str,
+    openai_client: Any,
+    temperature: float = 0.7,
+) -> str:
+    """Query a language model with ``prompt`` and return the output.
+
+    Parameters
+    ----------
+    prompt:
+        The text prompt to send to the language model.
+    openai_client:
+        Initialized OpenAI client with a ``chat.completions.create`` method.
+    temperature:
+        Sampling temperature for the model.
+
+    Returns
+    -------
+    str
+        Generated QE input file content or an empty string on error.
+    """
     try:
         response = openai_client.chat.completions.create(
             model="gpt-4",
             messages=[{"role": "user", "content": prompt}],
-            temperature=temperature
+            temperature=temperature,
         )
         return response.choices[0].message.content.strip()
     except Exception as e:


### PR DESCRIPTION
## Summary
- improve documentation for `TripleScoringModel`
- document `select_topk_triples`
- document utility functions
- add type hints to clarify inputs and outputs

## Testing
- `python -m py_compile policy_model.py sample_triples.py utils.py ppo_training_loop.py extract_kg_data.py sample_triples.py`

------
https://chatgpt.com/codex/tasks/task_e_686bc1e109dc832eae169456925e0630